### PR TITLE
Version 4.0.1

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
         title: 'Chassis.css',
         description: 'A minimalistic grid & typography CSS framework',
         author: '@joeleisner',
-        version: '4.0.0',
+        version: '4.0.1',
         siteUrl: 'https://chassis.joeleisner.com',
         defaultImage: '/images/thumbnail.png',
         navigation: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis.joeleisner.com",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,9 +3233,9 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chassis-css": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chassis-css/-/chassis-css-4.0.0.tgz",
-      "integrity": "sha512-r0ch/HqBoMz71y0mwXoxdpewxu/JlM35QasN916hhJcICs6wdOJinudWjB7y/3SiJslwgkPNZvk9gGw5fJXEqA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chassis-css/-/chassis-css-4.0.1.tgz",
+      "integrity": "sha512-m/t44hqybFjCrAshncLB2A41CLnDfPRgK2RBvaCpqC+BtVagRa8hlN4ff/75fGJT7LF3K1IEz+RXI6+7UvqYxQ=="
     },
     "cheerio": {
       "version": "1.0.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chassis.joeleisner.com",
   "private": true,
   "description": "The official documentation for chassis.css",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Joel Eisner <jeisner93@gmail.com>",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.21",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.10.1",
     "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "chassis-css": "^4.0.0",
+    "chassis-css": "^4.0.1",
     "gatsby": "^2.13.57",
     "gatsby-image": "^2.2.7",
     "gatsby-plugin-manifest": "^2.2.4",

--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -1,5 +1,5 @@
-import React      from 'react';
-import PropTypes  from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
     faInfoCircle,
     faExclamationCircle,
@@ -11,9 +11,9 @@ import Icon from './icon';
 import '../sass/components/alert.sass';
 
 const icons = {
-    info:    faInfoCircle,
+    info: faInfoCircle,
     warning: faExclamationCircle,
-    danger:  faExclamationCircle,
+    danger: faExclamationCircle,
     success: faCheckCircle
 };
 
@@ -21,18 +21,16 @@ const Alert = ({ type, children }) => {
     const icon = icons[type];
     return (
         <aside className="alert">
-            <div className={ `alert__icon alert__icon--${ type }` }>
-                <Icon icon={ icon } />
+            <div className={`alert__icon alert__icon--${type}`}>
+                <Icon icon={icon} />
             </div>
-            <div className="alert__content">
-                { children }
-            </div>
+            <div className="alert__content">{children}</div>
         </aside>
     );
 };
 
 Alert.propTypes = {
-    type:     PropTypes.string,
+    type: PropTypes.string,
     children: PropTypes.node.isRequired
 };
 

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -1,23 +1,28 @@
-import React               from 'react';
-import PropTypes           from 'prop-types';
-import SyntaxHighlighter   from 'react-syntax-highlighter';
-import Dark                from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
+import React from 'react';
+import PropTypes from 'prop-types';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import Dark from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 import '../sass/components/code.sass';
 
 class Code extends React.Component {
-    constructor(props) { super(props); }
+    constructor(props) {
+        super(props);
+    }
 
     state = {
-        copied:  false,
+        copied: false,
         example: ''
     };
 
     convertChildrenIntoCodeExample() {
-        const example = <div
-            className="code__example"
-            dangerouslySetInnerHTML={{ __html: this.props.children }}></div>;
+        const example = (
+            <div
+                className="code__example"
+                dangerouslySetInnerHTML={{ __html: this.props.children }}
+            ></div>
+        );
 
         this.setState({ example });
     }
@@ -36,13 +41,24 @@ class Code extends React.Component {
         const { language, example, children, ...props } = this.props;
         return (
             <div className="code">
-                { example ? this.state.example : '' }
+                {example ? this.state.example : ''}
                 <div className="code__snippet">
-                    <CopyToClipboard text={ children } onCopy={ this.onCopy.bind(this) }>
-                        <button className="code__copy">{ this.state.copied ? 'Copied!' : 'Copy' }</button>
+                    <CopyToClipboard
+                        text={children}
+                        onCopy={this.onCopy.bind(this)}
+                    >
+                        <button className="code__copy">
+                            {this.state.copied ? 'Copied!' : 'Copy'}
+                        </button>
                     </CopyToClipboard>
-                    <SyntaxHighlighter className="code__syntax" language={ language } style={ Dark } customStyle={{ padding: '1rem' }} { ...props }>
-                        { children }
+                    <SyntaxHighlighter
+                        className="code__syntax"
+                        language={language}
+                        style={Dark}
+                        customStyle={{ padding: '1rem' }}
+                        {...props}
+                    >
+                        {children}
                     </SyntaxHighlighter>
                 </div>
             </div>
@@ -52,13 +68,13 @@ class Code extends React.Component {
 
 Code.propTypes = {
     language: PropTypes.string,
-    example:  PropTypes.bool,
+    example: PropTypes.bool,
     children: PropTypes.string.isRequired
 };
 
 Code.defaultProps = {
     language: 'html',
-    example:  true
+    example: true
 };
 
 export default Code;

--- a/src/components/externallink.js
+++ b/src/components/externallink.js
@@ -1,16 +1,18 @@
-import React     from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const ExternalLink = ({ href, children, ...props }) => {
     if (props.title && !props['aria-label']) props['aria-label'] = props.title;
-    if (!props.title && props['aria-label']) props.title         = props['aria-label'];
+    if (!props.title && props['aria-label']) props.title = props['aria-label'];
     return (
-        <a href={ href } rel="noopener noreferrer" target="_blank" { ...props }>{ children }</a>
+        <a href={href} rel="noopener noreferrer" target="_blank" {...props}>
+            {children}
+        </a>
     );
 };
 
 ExternalLink.propTypes = {
-    href:     PropTypes.string.isRequired,
+    href: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired
 };
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,9 +1,9 @@
-import React                   from 'react';
-import { faHeart, faHome }     from '@fortawesome/free-solid-svg-icons';
+import React from 'react';
+import { faHeart, faHome } from '@fortawesome/free-solid-svg-icons';
 import { faTwitter, faGithub } from '@fortawesome/free-brands-svg-icons';
 
 import ExternalLink from './externallink';
-import Icon         from './icon';
+import Icon from './icon';
 
 import '../sass/components/footer.sass';
 
@@ -12,25 +12,53 @@ const Footer = () => (
         <div className="container">
             <div className="row">
                 <div className="footer__content">
-                    <p className="footer__copyright">©{ new Date().getFullYear() } - Joel Eisner</p>
+                    <p className="footer__copyright">
+                        ©{new Date().getFullYear()} - Joel Eisner
+                    </p>
                     <div className="footer__information">
-                        Made with
-                        { ' ' }
-                        <Icon icon={ faHeart } style={{ width: '1rem' }} text="love" />
-                        { ' using ' }
+                        Made with{' '}
+                        <Icon
+                            icon={faHeart}
+                            style={{ width: '1rem' }}
+                            text="love"
+                        />
+                        {' using '}
                         <strong>chassis.css</strong>
-                        { ' and ' }
-                        <ExternalLink href="https://www.gatsbyjs.org">Gatsby</ExternalLink>
+                        {' and '}
+                        <ExternalLink href="https://www.gatsbyjs.org">
+                            Gatsby
+                        </ExternalLink>
                     </div>
                     <nav className="footer__links">
-                        <ExternalLink href="http://www.joeleisner.com/" title="Joel Eisner's main website">
-                            <Icon icon={ faHome } style={{ width: '1rem' }} text="Joel Eisner's main website" />
+                        <ExternalLink
+                            href="http://www.joeleisner.com/"
+                            title="Joel Eisner's main website"
+                        >
+                            <Icon
+                                icon={faHome}
+                                style={{ width: '1rem' }}
+                                text="Joel Eisner's main website"
+                            />
                         </ExternalLink>
-                        <ExternalLink href="https://www.twitter.com/joeleisner" title="Joel Eisner's twitter page">
-                            <Icon icon={ faTwitter } style={{ width: '1rem' }} text="Joel Eisner's twitter page" />
+                        <ExternalLink
+                            href="https://www.twitter.com/joeleisner"
+                            title="Joel Eisner's twitter page"
+                        >
+                            <Icon
+                                icon={faTwitter}
+                                style={{ width: '1rem' }}
+                                text="Joel Eisner's twitter page"
+                            />
                         </ExternalLink>
-                        <ExternalLink href="https://www.github.com/joeleisner" title="Joel Eisner's GitHub page">
-                            <Icon icon={ faGithub } style={{ width: '1rem' }} text="Joel Eisner's GitHub page" />
+                        <ExternalLink
+                            href="https://www.github.com/joeleisner"
+                            title="Joel Eisner's GitHub page"
+                        >
+                            <Icon
+                                icon={faGithub}
+                                style={{ width: '1rem' }}
+                                text="Joel Eisner's GitHub page"
+                            />
                         </ExternalLink>
                     </nav>
                 </div>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,7 +1,7 @@
-import { Link }               from 'gatsby';
-import PropTypes              from 'prop-types';
-import React                  from 'react';
-import { faBars, faTimes }    from '@fortawesome/free-solid-svg-icons';
+import { Link } from 'gatsby';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import Icon from './icon';
 
@@ -11,7 +11,9 @@ import Wave from '../images/wave.svg';
 import '../sass/components/header.sass';
 
 class Header extends React.Component {
-    constructor(props) { super(props); }
+    constructor(props) {
+        super(props);
+    }
 
     state = { open: false };
 
@@ -22,13 +24,10 @@ class Header extends React.Component {
     }
 
     render() {
-        const {
-                title,
-                version,
-                navigation,
-                children
-            }          = this.props,
-            navClasses = [ 'header__nav', (this.state.open ? 'open' : '') ].filter(Boolean).join(' ');
+        const { title, version, navigation, children } = this.props,
+            navClasses = ['header__nav', this.state.open ? 'open' : '']
+                .filter(Boolean)
+                .join(' ');
         return (
             <header className="header">
                 <div className="container">
@@ -37,29 +36,52 @@ class Header extends React.Component {
                             <div className="header__level-wrapper">
                                 <div className="header__level">
                                     <div className="header__brand">
-                                        <Logo className="header__logo" role="presentation" />
+                                        <Logo
+                                            className="header__logo"
+                                            role="presentation"
+                                        />
                                         <div className="header__title-version">
-                                            <Link to="/">{ title }</Link>
-                                            <p>v{ version }</p>
+                                            <Link to="/">{title}</Link>
+                                            <p>v{version}</p>
                                         </div>
                                         <button
                                             className="header__nav-toggle"
                                             aria-controls="header__nav"
-                                            aria-expanded={ this.state.open }
+                                            aria-expanded={this.state.open}
                                             aria-label="Toggle navigation"
-                                            onClick={ this.toggleNav.bind(this) }><Icon icon={ this.state.open ? faTimes : faBars } /></button>
+                                            onClick={this.toggleNav.bind(this)}
+                                        >
+                                            <Icon
+                                                icon={
+                                                    this.state.open
+                                                        ? faTimes
+                                                        : faBars
+                                                }
+                                            />
+                                        </button>
                                     </div>
-                                    <nav id="header__nav" className={ navClasses }>
-                                        { navigation.map(({ path, name }) => <Link to={ path } className="header__nav-link" activeClassName="header__nav-link--active" partiallyActive={ true } key={ path }>{ name }</Link>) }
+                                    <nav
+                                        id="header__nav"
+                                        className={navClasses}
+                                    >
+                                        {navigation.map(({ path, name }) => (
+                                            <Link
+                                                to={path}
+                                                className="header__nav-link"
+                                                activeClassName="header__nav-link--active"
+                                                partiallyActive={true}
+                                                key={path}
+                                            >
+                                                {name}
+                                            </Link>
+                                        ))}
                                     </nav>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div className="row">
-                        <div className="col-6 header__summary">
-                            { children }
-                        </div>
+                        <div className="col-6 header__summary">{children}</div>
                     </div>
                 </div>
                 <Wave className="header__wave" role="presentation" />

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const Icon = ({ icon, text, ...props }) => {
-    const hiddenText = text ? <span className="sr">{ text }</span> : '';
+    const hiddenText = text ? <span className="sr">{text}</span> : '';
     return (
         <>
-            <FontAwesomeIcon icon={ icon } { ...props } role="presentation" />
-            { hiddenText }
+            <FontAwesomeIcon icon={icon} {...props} role="presentation" />
+            {hiddenText}
         </>
     );
 };

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -2,42 +2,40 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 
-import Header      from './header';
-import Footer      from './footer';
+import Header from './header';
+import Footer from './footer';
 import ScrollToTop from './scrolltotop';
 
 import '../sass/components/layout.sass';
 
 const Layout = ({ summary, children }) => {
     const data = useStaticQuery(graphql`
-        query DataQuery {
-            site {
-                siteMetadata {
-                    title,
-                    version,
-                    navigation {
-                        name,
-                        path
+            query DataQuery {
+                site {
+                    siteMetadata {
+                        title
+                        version
+                        navigation {
+                            name
+                            path
+                        }
                     }
                 }
             }
-        }
-    `),
-        {
-            title,
-            version,
-            navigation
-        } = data.site.siteMetadata;
+        `),
+        { title, version, navigation } = data.site.siteMetadata;
 
     return (
         <div className="site">
-            <Header title={ title } version={ version } navigation={ navigation }>{ typeof summary === 'function' ? summary() : summary }</Header>
+            <Header title={title} version={version} navigation={navigation}>
+                {typeof summary === 'function' ? summary() : summary}
+            </Header>
             <div className="site__content">
                 <div className="container">
                     <div className="row">
                         <div className="col">
                             <main>
-                                { children }
+                                {children}
                                 <ScrollToTop />
                             </main>
                         </div>

--- a/src/components/scrolltotop.js
+++ b/src/components/scrolltotop.js
@@ -1,4 +1,4 @@
-import React           from 'react';
+import React from 'react';
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons';
 
 import Icon from './icon';
@@ -10,20 +10,14 @@ class ScrollToTop extends React.Component {
         super(props);
 
         this.toggleVisibility = this.toggleVisibility.bind(this);
-        this.scroll           = this.scroll.bind(this);
+        this.scroll = this.scroll.bind(this);
     }
 
     state = { visible: false };
 
     toggleVisibility() {
-        const {
-                innerHeight: windowHeight,
-                pageYOffset: scrollOffset
-            }          = window,
-            {
-                body,
-                documentElement: html
-            }          = document,
+        const { innerHeight: windowHeight, pageYOffset: scrollOffset } = window,
+            { body, documentElement: html } = document,
             pageHeight = Math.max(
                 body.scrollHeight,
                 body.offsetHeight,
@@ -31,10 +25,12 @@ class ScrollToTop extends React.Component {
                 html.scrollHeight,
                 html.offsetHeight
             ),
-            fromTopThreshold    = scrollOffset > 400,
-            fromBottomThreshold = (windowHeight + scrollOffset) < pageHeight - 100;
+            fromTopThreshold = scrollOffset > 400,
+            fromBottomThreshold =
+                windowHeight + scrollOffset < pageHeight - 100;
 
-        if (fromTopThreshold && fromBottomThreshold) return this.setState({ visible: true });
+        if (fromTopThreshold && fromBottomThreshold)
+            return this.setState({ visible: true });
 
         return this.setState({ visible: false });
     }
@@ -56,13 +52,22 @@ class ScrollToTop extends React.Component {
     }
 
     render() {
-        const classes = [ 'scroll-to-top', this.state.visible ? 'scroll-to-top--visible' : '' ].filter(Boolean).join(' ');
+        const classes = [
+            'scroll-to-top',
+            this.state.visible ? 'scroll-to-top--visible' : ''
+        ]
+            .filter(Boolean)
+            .join(' ');
         return (
             <button
-                className={ classes }
-                onClick={ this.scroll }
-                ref={ element => this.element = element }>
-                <Icon icon={ faChevronUp } text="Scroll back to the top of the page" />
+                className={classes}
+                onClick={this.scroll}
+                ref={element => (this.element = element)}
+            >
+                <Icon
+                    icon={faChevronUp}
+                    text="Scroll back to the top of the page"
+                />
             </button>
         );
     }

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -32,8 +32,12 @@ function SEO({ description, lang, meta, title, image }) {
     return (
         <Helmet
             htmlAttributes={{ lang }}
-            title={ title }
-            titleTemplate={ title === site.siteMetadata.title ? `${ title } - ${ metaDescription }` : `%s - ${ site.siteMetadata.title }` }
+            title={title}
+            titleTemplate={
+                title === site.siteMetadata.title
+                    ? `${title} - ${metaDescription}`
+                    : `%s - ${site.siteMetadata.title}`
+            }
             meta={[
                 {
                     name: 'description',
@@ -49,7 +53,8 @@ function SEO({ description, lang, meta, title, image }) {
                 },
                 {
                     property: 'og:image',
-                    content: `${ site.siteMetadata.siteUrl }${ image || site.siteMetadata.defaultImage }`
+                    content: `${site.siteMetadata.siteUrl}${image ||
+                        site.siteMetadata.defaultImage}`
                 },
                 {
                     property: 'og:type',

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Layout from '../components/layout';
-import SEO    from '../components/seo';
+import SEO from '../components/seo';
 
 const Summary = () => (
     <>
@@ -11,13 +11,20 @@ const Summary = () => (
 );
 
 const NotFoundPage = () => (
-    <Layout summary={ Summary }>
+    <Layout summary={Summary}>
         <SEO title="Page Not found" />
         <h2>Things you can do.</h2>
         <ul>
             <li>Double check the URL for any misspellings.</li>
-            <li>Checkout the sitemap for pages that are similar to what you're looking for.</li>
-            <li>If you continue to reach this page, please contact <a href="mailto:jeisner93@gmail.com">jeisner93@gmail.com</a> so I can fix the mistake.</li>
+            <li>
+                Checkout the sitemap for pages that are similar to what you're
+                looking for.
+            </li>
+            <li>
+                If you continue to reach this page, please contact{' '}
+                <a href="mailto:jeisner93@gmail.com">jeisner93@gmail.com</a> so
+                I can fix the mistake.
+            </li>
         </ul>
     </Layout>
 );

--- a/src/pages/grid.js
+++ b/src/pages/grid.js
@@ -4,9 +4,10 @@ import Alert  from '../components/alert';
 import Code   from '../components/code';
 import Layout from '../components/layout';
 import SEO    from '../components/seo';
+import ExternalLink from '../components/externallink';
 
 const title     = 'Grid system',
-    description = 'The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it\'s very easy to get started!';
+    description = 'The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it\'s very easy to get started.';
 
 const Summary = () => (
     <>
@@ -84,18 +85,21 @@ const IndexPage = () => (
         <h3>Vertical column alignment</h3>
         <p>First, let's see how we can vertically align all columns within a row:</p>
         <Code>{`<div class="container">
-    <div class="row ai-c" style="height: 200px;">
+    <div class="row ai-c ac-c" style="height: 200px;">
         <div class="col-4">.col-4</div>
         <div class="col-4">.col-4</div>
         <div class="col-4">.col-4</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we are aligning the columns in the center of a row that has been manually set to 200px tall using the "align items" modifier classes. This is added to the row and follows the <code>.ai-*</code> class structure, where <code>*</code> can be one of the following letters:</p>
+        <p>In the above example, we are aligning the columns in the center of a row that has been manually set to 200px tall using one of the "align items" modifier classes and one of the "align content" modifier classes. This is added to the row and follows the <code>.ai-*</code> (align items) and <code>.ac-*</code> (align content) class structure, where <code>*</code> can be one of the following letters:</p>
         <ul>
             <li><code>s</code> means "start" and aligns columns to the top of the row.</li>
             <li><code>c</code> means "center" and aligns columns to the vertical-middle of the row.</li>
             <li><code>e</code> means "end" and aligns columns to the bottom of the row.</li>
         </ul>
+        <Alert>
+            <p>If you're confused about the differences between the "align items" modifier classes (which uses the flexbox <code>align-items</code> rule) and the "align content" modifier classes (which uses the flexbox <code>align-content</code> rule), check out this handy <ExternalLink href="https://medium.com/@wendersyang/what-the-flex-is-the-difference-between-justify-content-align-items-and-align-content-5fd3694f5259" title="What the flex is the difference between justify-content, align-items, and align-content?!">Medium article by Wendy Yang</ExternalLink>.</p>
+        </Alert>
         <p>There's also the "align self" modifier classes. These are added to a column, independently affecting its vertical alignment, and follow the <code>.as-*</code> class structure, where <code>*</code> can be one of the letters in the list above.</p>
         <Code>{`<div class="container">
     <div class="row" style="height: 200px;">
@@ -105,9 +109,6 @@ const IndexPage = () => (
     </div>
 </div>`}</Code>
         <p>In the above example, the first column is aligned to the top of the row, the second column is aligned to the middle of the row, and the third column is aligned to the bottom of the row.</p>
-        <Alert type="warning">
-            <p>Due to rows and flexbox works, vertical column alignments will become horizontal column alignments when the viewport is less than 768px.</p>
-        </Alert>
         <h3>Horizontal column alignment</h3>
         <p>Columns can also be vertically aligned using the "justify content" modifier classes. These are added to the row and follow the <code>.jc-*</code> class structure, where <code>*</code> is one of the following letters:</p>
         <ul>
@@ -146,9 +147,6 @@ const IndexPage = () => (
     </div>
 </div>`}</Code>
         <p>In the above example, each row has one of the possible "justify content" modifer classes on it.</p>
-        <Alert type="warning">
-            <p>Due to how rows and flexbox works, horizontal column alignments will become vertical column alignments when the viewport is less than 768px.</p>
-        </Alert>
         <h2>Column offsets</h2>
         <p>Columns can be offset from the start of a row or from a column to the left of itself using the "offset" modifier classes. These are added to a column and follow the <code>.os-*</code> class structure, where <code>*</code> is one of the following:</p>
         <ul>

--- a/src/pages/grid.js
+++ b/src/pages/grid.js
@@ -7,8 +7,7 @@ import SEO from '../components/seo';
 import ExternalLink from '../components/externallink';
 
 const title = 'Grid system',
-    description =
-        "The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it's very easy to get started.";
+    description = 'The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it\'s very easy to get started.';
 
 const Summary = () => (
     <>
@@ -118,7 +117,7 @@ const IndexPage = () => (
 </div>`}</Code>
         <p>
             In the above example, we have nested 3 layers of rows under various
-            arangements or columns without affecting the left or right alignment
+            arrangements or columns without affecting the left or right alignment
             of the text inside.
         </p>
         <h2>Column alignment</h2>
@@ -255,7 +254,7 @@ const IndexPage = () => (
 </div>`}</Code>
         <p>
             In the above example, each row has one of the possible "justify
-            content" modifer classes on it.
+            content" modifier classes on it.
         </p>
         <h2>Column offsets</h2>
         <p>
@@ -290,11 +289,11 @@ const IndexPage = () => (
 </div>`}</Code>
         <p>
             In the above example, the first row has two columns each taking up 4
-            of the avilable 12 column width with the second column automatically
-            offseting it from the first; <code>12 - (4 + 4) = 4</code>, so the
+            of the available 12 column width with the second column automatically
+            offsetting it from the first; <code>12 - (4 + 4) = 4</code>, so the
             offset is automatically taking up 4 of the available 12 column
             width. The second row has 3 columns each taking up 2 of the
-            available 12 column width with the second and third offseting itself
+            available 12 column width with the second and third offsetting itself
             from the previous by 3 of the available 12 column width;{' '}
             <code>2 + 3 + 2 + 3 + 2 = 12</code>.
         </p>
@@ -332,7 +331,7 @@ const IndexPage = () => (
         <p>
             In the above example, the first row has columns that are rendered in
             reverse order despite the order they were placed. The second row is
-            doing the same as the first row, except this reording will be reset
+            doing the same as the first row, except this reordering will be reset
             when the viewport is less than 768px wide.
         </p>
         <h3>Row reversing</h3>

--- a/src/pages/grid.js
+++ b/src/pages/grid.js
@@ -1,37 +1,50 @@
-import React  from 'react';
+import React from 'react';
 
-import Alert  from '../components/alert';
-import Code   from '../components/code';
+import Alert from '../components/alert';
+import Code from '../components/code';
 import Layout from '../components/layout';
-import SEO    from '../components/seo';
+import SEO from '../components/seo';
 import ExternalLink from '../components/externallink';
 
-const title     = 'Grid system',
-    description = 'The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it\'s very easy to get started.';
+const title = 'Grid system',
+    description =
+        "The chassis.css grid system uses a powerful, mobile-first, and flexbox-based 12-column layout. With no breakpoints to memorize and simple adjustment classes, it's very easy to get started.";
 
 const Summary = () => (
     <>
-        <h1>{ title }</h1>
-        <p>{ description }</p>
+        <h1>{title}</h1>
+        <p>{description}</p>
     </>
 );
 
 const IndexPage = () => (
-    <Layout summary={ Summary }>
-        <SEO
-            title={ title }
-            description={ description } />
+    <Layout summary={Summary}>
+        <SEO title={title} description={description} />
         <h2>The basics</h2>
-        <p>There's a few things to keep in mind when using the chassis.css grid system.</p>
+        <p>
+            There's a few things to keep in mind when using the chassis.css grid
+            system.
+        </p>
         <ul>
-            <li>Rows are meant to be inside a <code>.container</code>.</li>
-            <li>Columns are meant to be inside a <code>.row</code>.</li>
+            <li>
+                Rows are meant to be inside a <code>.container</code>.
+            </li>
+            <li>
+                Columns are meant to be inside a <code>.row</code>.
+            </li>
             <li>Column widths can add up to 12 within a row.</li>
-            <li>Columns will become 100% width and vertically stacked when the viewport is less than 768px wide.</li>
+            <li>
+                Columns will become 100% width and vertically stacked when the
+                viewport is less than 768px wide.
+            </li>
         </ul>
         <p>Makes sense, right? Let's dive deeper.</p>
         <h3>Fixed width columns</h3>
-        <p>Columns with fixed widths always follow the <code>.col-*</code> class structure, where <code>*</code> can be any number between 1 and 12. Let's see this in action below:</p>
+        <p>
+            Columns with fixed widths always follow the <code>.col-*</code>{' '}
+            class structure, where <code>*</code> can be any number between 1
+            and 12. Let's see this in action below:
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col-4">.col-4</div>
@@ -39,9 +52,18 @@ const IndexPage = () => (
         <div class="col-4">.col-4</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we have three columns each taking up 4 of the available 12 column width; <code>3 x 4 = 12</code>.</p>
+        <p>
+            In the above example, we have three columns each taking up 4 of the
+            available 12 column width; <code>3 x 4 = 12</code>.
+        </p>
         <h3>Auto width columns</h3>
-        <p>Columns don't require a fixed width, however. Auto width columns use the <code>.col</code> class, and will take up the remainder of horizontal space when next to set-width columns. A row of all auto width columns will divide the horizontal space up evenly. Let's redo the first example with auto-width columns:</p>
+        <p>
+            Columns don't require a fixed width, however. Auto width columns use
+            the <code>.col</code> class, and will take up the remainder of
+            horizontal space when next to set-width columns. A row of all auto
+            width columns will divide the horizontal space up evenly. Let's redo
+            the first example with auto-width columns:
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col">.col</div>
@@ -49,16 +71,31 @@ const IndexPage = () => (
         <div class="col">.col</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we have three auto width columns sharing the horizontal space evenly, rendering an identical result to the first example; <code>12 / 3 = 4</code>, so the auto width columns will automatically take up 4 of the available 12 column width. As stated before, auto width columns can be paired with fixed width columns, taking up the remaining horizontal space:</p>
+        <p>
+            In the above example, we have three auto width columns sharing the
+            horizontal space evenly, rendering an identical result to the first
+            example; <code>12 / 3 = 4</code>, so the auto width columns will
+            automatically take up 4 of the available 12 column width. As stated
+            before, auto width columns can be paired with fixed width columns,
+            taking up the remaining horizontal space:
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col-3">.col-3</div>
         <div class="col">.col</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we have a fixed width column taking up 3 of the available 12 column width, and an auto width column taking up the remaining horizontal space; <code>12 - 3 = 9</code>, so the auto width column will take up 9 of the available 12 column width.</p>
+        <p>
+            In the above example, we have a fixed width column taking up 3 of
+            the available 12 column width, and an auto width column taking up
+            the remaining horizontal space; <code>12 - 3 = 9</code>, so the auto
+            width column will take up 9 of the available 12 column width.
+        </p>
         <h3>Row nesting</h3>
-        <p>Rows of columns can be can be nested within other rows without affecting the left or right alignment of the content inside:</p>
+        <p>
+            Rows of columns can be can be nested within other rows without
+            affecting the left or right alignment of the content inside:
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col">.col
@@ -79,11 +116,23 @@ const IndexPage = () => (
         </div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we have nested 3 layers of rows under various arangements or columns without affecting the left or right alignment of the text inside.</p>
+        <p>
+            In the above example, we have nested 3 layers of rows under various
+            arangements or columns without affecting the left or right alignment
+            of the text inside.
+        </p>
         <h2>Column alignment</h2>
-        <p>Columns can be vertically and horizontally aligned however you like! This can be done by adding modifier classes to the row itself, globally aligning the columns within it, or in some instances to individual columns, aligning the column independently of the rest.</p>
+        <p>
+            Columns can be vertically and horizontally aligned however you like!
+            This can be done by adding modifier classes to the row itself,
+            globally aligning the columns within it, or in some instances to
+            individual columns, aligning the column independently of the rest.
+        </p>
         <h3>Vertical column alignment</h3>
-        <p>First, let's see how we can vertically align all columns within a row:</p>
+        <p>
+            First, let's see how we can vertically align all columns within a
+            row:
+        </p>
         <Code>{`<div class="container">
     <div class="row ai-c ac-c" style="height: 200px;">
         <div class="col-4">.col-4</div>
@@ -91,16 +140,50 @@ const IndexPage = () => (
         <div class="col-4">.col-4</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, we are aligning the columns in the center of a row that has been manually set to 200px tall using one of the "align items" modifier classes and one of the "align content" modifier classes. This is added to the row and follows the <code>.ai-*</code> (align items) and <code>.ac-*</code> (align content) class structure, where <code>*</code> can be one of the following letters:</p>
+        <p>
+            In the above example, we are aligning the columns in the center of a
+            row that has been manually set to 200px tall using one of the "align
+            items" modifier classes and one of the "align content" modifier
+            classes. This is added to the row and follows the <code>.ai-*</code>{' '}
+            (align items) and <code>.ac-*</code> (align content) class
+            structure, where <code>*</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>s</code> means "start" and aligns columns to the top of the row.</li>
-            <li><code>c</code> means "center" and aligns columns to the vertical-middle of the row.</li>
-            <li><code>e</code> means "end" and aligns columns to the bottom of the row.</li>
+            <li>
+                <code>s</code> means "start" and aligns columns to the top of
+                the row.
+            </li>
+            <li>
+                <code>c</code> means "center" and aligns columns to the
+                vertical-middle of the row.
+            </li>
+            <li>
+                <code>e</code> means "end" and aligns columns to the bottom of
+                the row.
+            </li>
         </ul>
         <Alert>
-            <p>If you're confused about the differences between the "align items" modifier classes (which uses the flexbox <code>align-items</code> rule) and the "align content" modifier classes (which uses the flexbox <code>align-content</code> rule), check out this handy <ExternalLink href="https://medium.com/@wendersyang/what-the-flex-is-the-difference-between-justify-content-align-items-and-align-content-5fd3694f5259" title="What the flex is the difference between justify-content, align-items, and align-content?!">Medium article by Wendy Yang</ExternalLink>.</p>
+            <p>
+                If you're confused about the differences between the "align
+                items" modifier classes (which uses the flexbox{' '}
+                <code>align-items</code> rule) and the "align content" modifier
+                classes (which uses the flexbox <code>align-content</code>{' '}
+                rule), check out this handy{' '}
+                <ExternalLink
+                    href="https://medium.com/@wendersyang/what-the-flex-is-the-difference-between-justify-content-align-items-and-align-content-5fd3694f5259"
+                    title="What the flex is the difference between justify-content, align-items, and align-content?!"
+                >
+                    Medium article by Wendy Yang
+                </ExternalLink>
+                .
+            </p>
         </Alert>
-        <p>There's also the "align self" modifier classes. These are added to a column, independently affecting its vertical alignment, and follow the <code>.as-*</code> class structure, where <code>*</code> can be one of the letters in the list above.</p>
+        <p>
+            There's also the "align self" modifier classes. These are added to a
+            column, independently affecting its vertical alignment, and follow
+            the <code>.as-*</code> class structure, where <code>*</code> can be
+            one of the letters in the list above.
+        </p>
         <Code>{`<div class="container">
     <div class="row" style="height: 200px;">
         <div class="col-4 as-s">.col-4.as-s</div>
@@ -108,15 +191,39 @@ const IndexPage = () => (
         <div class="col-4 as-e">.col-4.as-e</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, the first column is aligned to the top of the row, the second column is aligned to the middle of the row, and the third column is aligned to the bottom of the row.</p>
+        <p>
+            In the above example, the first column is aligned to the top of the
+            row, the second column is aligned to the middle of the row, and the
+            third column is aligned to the bottom of the row.
+        </p>
         <h3>Horizontal column alignment</h3>
-        <p>Columns can also be vertically aligned using the "justify content" modifier classes. These are added to the row and follow the <code>.jc-*</code> class structure, where <code>*</code> is one of the following letters:</p>
+        <p>
+            Columns can also be vertically aligned using the "justify content"
+            modifier classes. These are added to the row and follow the{' '}
+            <code>.jc-*</code> class structure, where <code>*</code> is one of
+            the following letters:
+        </p>
         <ul>
-            <li><code>s</code> means "start" and aligns columns to the left of the row.</li>
-            <li><code>c</code> means "center" and aligns columns to the horizontal-middle of the row.</li>
-            <li><code>e</code> means "end" and aligns columns to the right of the row.</li>
-            <li><code>a</code> means "space around" and aligns columns with an even amount of horizontal space around them.</li>
-            <li><code>b</code> means "space between" and aligns columns with an even amount of horizontal space between them.</li>
+            <li>
+                <code>s</code> means "start" and aligns columns to the left of
+                the row.
+            </li>
+            <li>
+                <code>c</code> means "center" and aligns columns to the
+                horizontal-middle of the row.
+            </li>
+            <li>
+                <code>e</code> means "end" and aligns columns to the right of
+                the row.
+            </li>
+            <li>
+                <code>a</code> means "space around" and aligns columns with an
+                even amount of horizontal space around them.
+            </li>
+            <li>
+                <code>b</code> means "space between" and aligns columns with an
+                even amount of horizontal space between them.
+            </li>
         </ul>
         <p>Let's check it out:</p>
         <Code>{`<div class="container">
@@ -146,14 +253,30 @@ const IndexPage = () => (
         <div class="col-1">.col-1</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, each row has one of the possible "justify content" modifer classes on it.</p>
+        <p>
+            In the above example, each row has one of the possible "justify
+            content" modifer classes on it.
+        </p>
         <h2>Column offsets</h2>
-        <p>Columns can be offset from the start of a row or from a column to the left of itself using the "offset" modifier classes. These are added to a column and follow the <code>.os-*</code> class structure, where <code>*</code> is one of the following:</p>
+        <p>
+            Columns can be offset from the start of a row or from a column to
+            the left of itself using the "offset" modifier classes. These are
+            added to a column and follow the <code>.os-*</code> class structure,
+            where <code>*</code> is one of the following:
+        </p>
         <ul>
-            <li><code>a</code> means "auto" and puts as much space as possible to the left of the column.</li>
-            <li>Any number between 1 and 12 corresponding to a column width.</li>
+            <li>
+                <code>a</code> means "auto" and puts as much space as possible
+                to the left of the column.
+            </li>
+            <li>
+                Any number between 1 and 12 corresponding to a column width.
+            </li>
         </ul>
-        <p>When the viewport is less than 768px wide, these offsets will be removed. Let's see this in action:</p>
+        <p>
+            When the viewport is less than 768px wide, these offsets will be
+            removed. Let's see this in action:
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col-4">.col-4</div>
@@ -165,12 +288,34 @@ const IndexPage = () => (
         <div class="col-2 os-3">.col-2.os-3</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, the first row has two columns each taking up 4 of the avilable 12 column width with the second column automatically offseting it from the first; <code>12 - (4 + 4) = 4</code>, so the offset is automatically taking up 4 of the available 12 column width. The second row has 3 columns each taking up 2 of the available 12 column width with the second and third offseting itself from the previous by 3 of the available 12 column width; <code>2 + 3 + 2 + 3 + 2 = 12</code>.</p>
+        <p>
+            In the above example, the first row has two columns each taking up 4
+            of the avilable 12 column width with the second column automatically
+            offseting it from the first; <code>12 - (4 + 4) = 4</code>, so the
+            offset is automatically taking up 4 of the available 12 column
+            width. The second row has 3 columns each taking up 2 of the
+            available 12 column width with the second and third offseting itself
+            from the previous by 3 of the available 12 column width;{' '}
+            <code>2 + 3 + 2 + 3 + 2 = 12</code>.
+        </p>
         <h2>Column order</h2>
-        <p>Columns can be ordered relatively from one another independently of the order they are placed in the row using the "order" modifier classes. These are added to a column and follow one of the following class structures where <code>*</code> is any number 1 and 12:</p>
+        <p>
+            Columns can be ordered relatively from one another independently of
+            the order they are placed in the row using the "order" modifier
+            classes. These are added to a column and follow one of the following
+            class structures where <code>*</code> is any number 1 and 12:
+        </p>
         <ul>
-            <li><code>.or-*</code> changes the order of a column on all size viewports.</li>
-            <li><code>.or-r*</code> changes the order of a column but resets the order when the viewport is less than 768px wide. This is similar behavior to the previous "push/pull" modifier classes in previous versions of this framework.</li>
+            <li>
+                <code>.or-*</code> changes the order of a column on all size
+                viewports.
+            </li>
+            <li>
+                <code>.or-r*</code> changes the order of a column but resets the
+                order when the viewport is less than 768px wide. This is similar
+                behavior to the previous "push/pull" modifier classes in
+                previous versions of this framework.
+            </li>
         </ul>
         <Code>{`<div class="container">
     <div class="row">
@@ -184,9 +329,19 @@ const IndexPage = () => (
         <div class="col-4 or-r1">.col-4.or-r1</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, the first row has columns that are rendered in reverse order despite the order they were placed. The second row is doing the same as the first row, except this reording will be reset when the viewport is less than 768px wide.</p>
+        <p>
+            In the above example, the first row has columns that are rendered in
+            reverse order despite the order they were placed. The second row is
+            doing the same as the first row, except this reording will be reset
+            when the viewport is less than 768px wide.
+        </p>
         <h3>Row reversing</h3>
-        <p>The first row from the above example can also be accomplished using the "reverse" modifier class. This is added to a row and uses the <code>.rev</code> class. This will not be reset when the viewport is less than 768px wide.</p>
+        <p>
+            The first row from the above example can also be accomplished using
+            the "reverse" modifier class. This is added to a row and uses the{' '}
+            <code>.rev</code> class. This will not be reset when the viewport is
+            less than 768px wide.
+        </p>
         <Code>{`<div class="container">
     <div class="row rev">
         <div class="col-2">.col-2</div>
@@ -194,9 +349,17 @@ const IndexPage = () => (
         <div class="col-7">.col-7</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, the row has columns that are rendered in reverse order despite the order they were placed.</p>
+        <p>
+            In the above example, the row has columns that are rendered in
+            reverse order despite the order they were placed.
+        </p>
         <Alert>
-            <p>If you're familiar with how CSS flexbox works, you can use the modifier classes listed above on any <code>display: flex</code> elements or its children, as these use the flexbox alignment rules.</p>
+            <p>
+                If you're familiar with how CSS flexbox works, you can use the
+                modifier classes listed above on any <code>display: flex</code>{' '}
+                elements or its children, as these use the flexbox alignment
+                rules.
+            </p>
         </Alert>
     </Layout>
 );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React        from 'react';
+import React from 'react';
 import {
     faArrowCircleDown,
     faAsterisk,
@@ -8,105 +8,203 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
-import Code         from '../components/code';
+import Code from '../components/code';
 import ExternalLink from '../components/externallink';
-import Icon         from '../components/icon';
-import Layout       from '../components/layout';
-import SEO          from '../components/seo';
+import Icon from '../components/icon';
+import Layout from '../components/layout';
+import SEO from '../components/seo';
 
 import '../sass/pages/index.sass';
 
-const title     = 'Chassis.css',
-    tagline     = 'A minimalistic grid & typography CSS framework.',
-    description = 'Chassis.css provides easy-to-use and lightweight styling with practical defaults without being too opinionated.';
+const title = 'Chassis.css',
+    tagline = 'A minimalistic grid & typography CSS framework.',
+    description =
+        'Chassis.css provides easy-to-use and lightweight styling with practical defaults without being too opinionated.';
 
 const Summary = () => (
     <>
-        <h1>{ tagline }</h1>
-        <p>{ description }</p>
+        <h1>{tagline}</h1>
+        <p>{description}</p>
         <div className="index__buttons">
             <ExternalLink
                 href="https://github.com/joeleisner/chassis-css/releases"
                 title="Chassis.css GitHub releases"
-                className="index__button index__button--highlight"><Icon icon={ faArrowCircleDown } style={{ width: '1em' }} />Download</ExternalLink>
+                className="index__button index__button--highlight"
+            >
+                <Icon icon={faArrowCircleDown} style={{ width: '1em' }} />
+                Download
+            </ExternalLink>
             <ExternalLink
                 href="https://github.com/joeleisner/chassis-css"
                 title="Chassis.css GitHub"
-                className="index__button"><Icon icon={ faGithub } style={{ width: '1em' }} />GitHub</ExternalLink>
+                className="index__button"
+            >
+                <Icon icon={faGithub} style={{ width: '1em' }} />
+                GitHub
+            </ExternalLink>
             <ExternalLink
                 href="http://joeleisner.com/chassis"
                 title="Chassis.css v3.0.2 documentation"
-                className="index__button"><Icon icon={ faBook } style={{ width: '1em' }} />v3.0.2<span className="sr">documentation</span></ExternalLink>
+                className="index__button"
+            >
+                <Icon icon={faBook} style={{ width: '1em' }} />
+                v3.0.2<span className="sr">documentation</span>
+            </ExternalLink>
         </div>
     </>
 );
 
 const IndexPage = () => (
-    <Layout summary={ Summary }>
-        <SEO
-            title={ title }
-            description={ [ tagline, description ].join(' ') } />
+    <Layout summary={Summary}>
+        <SEO title={title} description={[tagline, description].join(' ')} />
         <div className="row">
             <div className="col">
                 <div className="index__perk">
-                    <h2 className="index__perk-title"><Icon icon={ faExpand } style={{ width: '1.75rem' }} />Expandable</h2>
-                    <p className="index__perk-description">Chassis.css sets out to deliver web developers core features, like a grid system and typography defaults, without too much styling.</p>
+                    <h2 className="index__perk-title">
+                        <Icon icon={faExpand} style={{ width: '1.75rem' }} />
+                        Expandable
+                    </h2>
+                    <p className="index__perk-description">
+                        Chassis.css sets out to deliver web developers core
+                        features, like a grid system and typography defaults,
+                        without too much styling.
+                    </p>
                 </div>
             </div>
             <div className="col">
                 <div className="index__perk">
-                    <h2 className="index__perk-title"><Icon icon={ faFeather } style={{ width: '1.75rem' }} />Lightweight</h2>
-                    <p className="index__perk-description">At just 1.6KB minified and gzipped, chassis.css has a lot of room for you to add your own touch. No bloat or extras; Just the bare necessities.</p>
+                    <h2 className="index__perk-title">
+                        <Icon icon={faFeather} style={{ width: '1.75rem' }} />
+                        Lightweight
+                    </h2>
+                    <p className="index__perk-description">
+                        At just 1.6KB minified and gzipped, chassis.css has a
+                        lot of room for you to add your own touch. No bloat or
+                        extras; Just the bare necessities.
+                    </p>
                 </div>
             </div>
             <div className="col">
                 <div className="index__perk">
-                    <h2 className="index__perk-title"><Icon icon={ faAsterisk } style={{ width: '1.75rem' }} />Modern</h2>
-                    <p className="index__perk-description">Built mobile-first using newer web technologies such as CSS flexbox, chassis.css provides a modern framework for your modern workflow.</p>
+                    <h2 className="index__perk-title">
+                        <Icon icon={faAsterisk} style={{ width: '1.75rem' }} />
+                        Modern
+                    </h2>
+                    <p className="index__perk-description">
+                        Built mobile-first using newer web technologies such as
+                        CSS flexbox, chassis.css provides a modern framework for
+                        your modern workflow.
+                    </p>
                 </div>
             </div>
         </div>
         <h2>Installation</h2>
-        <Code language="shell" example={ false }>npm install chassis-css</Code>
+        <Code language="shell" example={false}>
+            npm install chassis-css
+        </Code>
         <h2>Changelog</h2>
         <h3>4.0.1</h3>
-        <p>This patch brings some much needed stability to the framework after its big release. Here's what to expect:</p>
+        <p>
+            This patch brings some much needed stability to the framework after
+            its big release. Here's what to expect:
+        </p>
         <ul>
-            <li>Rows no longer change their <code>flex-direction</code> between <code>column</code> on extra small viewports and <code>row</code> on small viewports and above.
+            <li>
+                Rows no longer change their <code>flex-direction</code> between{' '}
+                <code>column</code> on extra small viewports and{' '}
+                <code>row</code> on small viewports and above.
                 <ul>
                     <li>Rows now wrap columns to vertically stack them.</li>
-                    <li>Vertical and horizontal alignment modifier classes no longer flip-flop functionality between extra small and small viewports.</li>
-                    <li>The reverse row modifier class, <code>.row.rev</code>, has been changed.</li>
-                    <li>The way columns fill the row's width on extra small viewports has been changed.</li>
+                    <li>
+                        Vertical and horizontal alignment modifier classes no
+                        longer flip-flop functionality between extra small and
+                        small viewports.
+                    </li>
+                    <li>
+                        The reverse row modifier class, <code>.row.rev</code>,
+                        has been changed.
+                    </li>
+                    <li>
+                        The way columns fill the row's width on extra small
+                        viewports has been changed.
+                    </li>
                 </ul>
             </li>
-            <li>New align content modifier classes, <code>.ac-*</code>, have been added to provide more vertical alignment options.</li>
+            <li>
+                New align content modifier classes, <code>.ac-*</code>, have
+                been added to provide more vertical alignment options.
+            </li>
         </ul>
         <h3>4.0.0</h3>
-        <p>Chassis.css has been overhauled from the ground up to support some killer new features. Here's what you can look forward to:</p>
+        <p>
+            Chassis.css has been overhauled from the ground up to support some
+            killer new features. Here's what you can look forward to:
+        </p>
         <ul>
-            <li>The grid system now uses Flexbox!
+            <li>
+                The grid system now uses Flexbox!
                 <ul>
-                    <li>You can simply use the <code>.col</code> class to automatically take up remaining space in a row.</li>
-                    <li><code>.row.rev</code> allows you to quickly reverse the order of a row.</li>
-                    <li>Gone are the days of push/pull - You can now order/space your columns with <code>.or-*</code> (order), <code>.or-r*</code> (order reset on mobile), and <code>.os-*</code> (offset) classes.</li>
-                    <li>You can now vertically/horizontally align columns with <code>.ai-*</code> (align-items), <code>.as-*</code> (align-self), and <code>.jc-*</code> (justify-content) classes.</li>
+                    <li>
+                        You can simply use the <code>.col</code> class to
+                        automatically take up remaining space in a row.
+                    </li>
+                    <li>
+                        <code>.row.rev</code> allows you to quickly reverse the
+                        order of a row.
+                    </li>
+                    <li>
+                        Gone are the days of push/pull - You can now order/space
+                        your columns with <code>.or-*</code> (order),{' '}
+                        <code>.or-r*</code> (order reset on mobile), and{' '}
+                        <code>.os-*</code> (offset) classes.
+                    </li>
+                    <li>
+                        You can now vertically/horizontally align columns with{' '}
+                        <code>.ai-*</code> (align-items), <code>.as-*</code>{' '}
+                        (align-self), and <code>.jc-*</code> (justify-content)
+                        classes.
+                    </li>
                 </ul>
             </li>
-            <li>The reset and typography defaults have been ironed out.
+            <li>
+                The reset and typography defaults have been ironed out.
                 <ul>
-                    <li>The reset only overrides necessary things and avoids practices that can compromise accessibility.</li>
-                    <li>Overall sizes and spacing between typography elements have been simplified dramatically.</li>
-                    <li>New heading <code>.h*</code> classes allow you to make any typography element look like a heading.</li>
+                    <li>
+                        The reset only overrides necessary things and avoids
+                        practices that can compromise accessibility.
+                    </li>
+                    <li>
+                        Overall sizes and spacing between typography elements
+                        have been simplified dramatically.
+                    </li>
+                    <li>
+                        New heading <code>.h*</code> classes allow you to make
+                        any typography element look like a heading.
+                    </li>
                 </ul>
             </li>
-            <li>Utility classes, particularly for margins/padding, have become way more concise/versatile.
+            <li>
+                Utility classes, particularly for margins/padding, have become
+                way more concise/versatile.
                 <ul>
-                    <li>These classes are now constructable, allowing you to target all/specfic sides, add negative/positive adjustments, and utilize 6 levels of adjustments.</li>
+                    <li>
+                        These classes are now constructable, allowing you to
+                        target all/specfic sides, add negative/positive
+                        adjustments, and utilize 6 levels of adjustments.
+                    </li>
                 </ul>
             </li>
         </ul>
-        <p>Check out the <ExternalLink href="https://github.com/joeleisner/chassis-css/blob/master/changelog.md" title="Chassis.css GitHub changelog">changelog</ExternalLink> for previous release information.</p>
+        <p>
+            Check out the{' '}
+            <ExternalLink
+                href="https://github.com/joeleisner/chassis-css/blob/master/changelog.md"
+                title="Chassis.css GitHub changelog"
+            >
+                changelog
+            </ExternalLink>{' '}
+            for previous release information.
+        </p>
     </Layout>
 );
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,7 +66,23 @@ const IndexPage = () => (
                 </div>
             </div>
         </div>
+        <h2>Installation</h2>
+        <Code language="shell" example={ false }>npm install chassis-css</Code>
         <h2>Changelog</h2>
+        <h3>4.0.1</h3>
+        <p>This patch brings some much needed stability to the framework after its big release. Here's what to expect:</p>
+        <ul>
+            <li>Rows no longer change their <code>flex-direction</code> between <code>column</code> on extra small viewports and <code>row</code> on small viewports and above.
+                <ul>
+                    <li>Rows now wrap columns to vertically stack them.</li>
+                    <li>Vertical and horizontal alignment modifier classes no longer flip-flop functionality between extra small and small viewports.</li>
+                    <li>The reverse row modifier class, <code>.row.rev</code>, has been changed.</li>
+                    <li>The way columns fill the row's width on extra small viewports has been changed.</li>
+                </ul>
+            </li>
+            <li>New align content modifier classes, <code>.ac-*</code>, have been added to provide more vertical alignment options.</li>
+        </ul>
+        <h3>4.0.0</h3>
         <p>Chassis.css has been overhauled from the ground up to support some killer new features. Here's what you can look forward to:</p>
         <ul>
             <li>The grid system now uses Flexbox!
@@ -90,8 +106,7 @@ const IndexPage = () => (
                 </ul>
             </li>
         </ul>
-        <h2>Installation</h2>
-        <Code language="shell" example={ false }>npm install chassis-css</Code>
+        <p>Check out the <ExternalLink href="https://github.com/joeleisner/chassis-css/blob/master/changelog.md" title="Chassis.css GitHub changelog">changelog</ExternalLink> for previous release information.</p>
     </Layout>
 );
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -189,7 +189,7 @@ const IndexPage = () => (
                 <ul>
                     <li>
                         These classes are now constructable, allowing you to
-                        target all/specfic sides, add negative/positive
+                        target all/specific sides, add negative/positive
                         adjustments, and utilize 6 levels of adjustments.
                     </li>
                 </ul>

--- a/src/pages/reset.js
+++ b/src/pages/reset.js
@@ -92,7 +92,7 @@ const IndexPage = () => (
         <p>
             In the above example, there are 6 paragraph elements styled to look
             like <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code>.
-            Heading classes folow the <code>.h*</code> class structure, where{' '}
+            Heading classes follow the <code>.h*</code> class structure, where{' '}
             <code>*</code> can be a number between 1 and 6.
         </p>
         <Alert>

--- a/src/pages/reset.js
+++ b/src/pages/reset.js
@@ -6,7 +6,7 @@ import Layout from '../components/layout';
 import SEO    from '../components/seo';
 
 const title     = 'Style resets',
-    description = 'The chassis.css style resets provide a minimalistic, versatile, and accessibility focused baseline for elements and typography. With little-to-no extra styling and practical sizes and spacing, it provides a solid foundation!';
+    description = 'The chassis.css style resets provide a minimalistic, versatile, and accessibility focused baseline for elements and typography. With little-to-no extra styling and practical sizes and spacing, it provides a solid foundation.';
 
 const Summary = () => (
     <>

--- a/src/pages/reset.js
+++ b/src/pages/reset.js
@@ -1,62 +1,107 @@
 import React from 'react';
 
-import Alert  from '../components/alert';
-import Code   from '../components/code';
+import Alert from '../components/alert';
+import Code from '../components/code';
 import Layout from '../components/layout';
-import SEO    from '../components/seo';
+import SEO from '../components/seo';
 
-const title     = 'Style resets',
-    description = 'The chassis.css style resets provide a minimalistic, versatile, and accessibility focused baseline for elements and typography. With little-to-no extra styling and practical sizes and spacing, it provides a solid foundation.';
+const title = 'Style resets',
+    description =
+        'The chassis.css style resets provide a minimalistic, versatile, and accessibility focused baseline for elements and typography. With little-to-no extra styling and practical sizes and spacing, it provides a solid foundation.';
 
 const Summary = () => (
     <>
-        <h1>{ title }</h1>
-        <p>{ description }</p>
+        <h1>{title}</h1>
+        <p>{description}</p>
     </>
 );
 
 const IndexPage = () => (
-    <Layout summary={ Summary }>
-        <SEO
-            title={ title }
-            description={ description } />
+    <Layout summary={Summary}>
+        <SEO title={title} description={description} />
         <h2>The basics</h2>
-        <p>The chassis.css style resets come with a handful of defaults to keep in mind.</p>
+        <p>
+            The chassis.css style resets come with a handful of defaults to keep
+            in mind.
+        </p>
         <ul>
-            <li>All elements and pseudo-elements are set to <code>box-sizing: border-box</code>.</li>
-            <li>The root font size is <code>16px</code> with no font family applied out of the box and a line height of <code>1.15</code>.</li>
+            <li>
+                All elements and pseudo-elements are set to{' '}
+                <code>box-sizing: border-box</code>.
+            </li>
+            <li>
+                The root font size is <code>16px</code> with no font family
+                applied out of the box and a line height of <code>1.15</code>.
+            </li>
             <li>Font smoothing is applied to all elements.</li>
-            <li>Top margins are removed from all elements in favor of just using bottom margins.</li>
+            <li>
+                Top margins are removed from all elements in favor of just using
+                bottom margins.
+            </li>
         </ul>
         <p>Pretty practical, right? Let's check it out.</p>
         <h2>Headings</h2>
-        <p>Heading styles are provided for <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code>:</p>
+        <p>
+            Heading styles are provided for <code>&lt;h1&gt;</code> through{' '}
+            <code>&lt;h6&gt;</code>:
+        </p>
         <Code>{`<h1>Heading 1</h1>
 <h2>Heading 2</h2>
 <h3>Heading 3</h3>
 <h4>Heading 4</h4>
 <h5>Heading 5</h5>
 <h6>Heading 6</h6>`}</Code>
-        <p>In the above example, headings <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code> are displayed. Every heading has a bottom margin of <code>.5rem</code> with the following font sizes:</p>
+        <p>
+            In the above example, headings <code>&lt;h1&gt;</code> through{' '}
+            <code>&lt;h6&gt;</code> are displayed. Every heading has a bottom
+            margin of <code>.5rem</code> with the following font sizes:
+        </p>
         <ul>
-            <li><code>&lt;h1&gt;</code> has a font size of <code>2.5rem</code>.</li>
-            <li><code>&lt;h2&gt;</code> has a font size of <code>2rem</code>.</li>
-            <li><code>&lt;h3&gt;</code> has a font size of <code>1.75rem</code>.</li>
-            <li><code>&lt;h4&gt;</code> has a font size of <code>1.5rem</code>.</li>
-            <li><code>&lt;h5&gt;</code> has a font size of <code>1.25rem</code>.</li>
-            <li><code>&lt;h6&gt;</code> has a font size of <code>1rem</code>.</li>
+            <li>
+                <code>&lt;h1&gt;</code> has a font size of <code>2.5rem</code>.
+            </li>
+            <li>
+                <code>&lt;h2&gt;</code> has a font size of <code>2rem</code>.
+            </li>
+            <li>
+                <code>&lt;h3&gt;</code> has a font size of <code>1.75rem</code>.
+            </li>
+            <li>
+                <code>&lt;h4&gt;</code> has a font size of <code>1.5rem</code>.
+            </li>
+            <li>
+                <code>&lt;h5&gt;</code> has a font size of <code>1.25rem</code>.
+            </li>
+            <li>
+                <code>&lt;h6&gt;</code> has a font size of <code>1rem</code>.
+            </li>
         </ul>
         <h3>Heading classes</h3>
-        <p>Sometimes you want to style elements to look like headings, especially in the event that an actual heading element does make sense logically or from an accessibility standpoint; That's where heading classes come in handy:</p>
+        <p>
+            Sometimes you want to style elements to look like headings,
+            especially in the event that an actual heading element does make
+            sense logically or from an accessibility standpoint; That's where
+            heading classes come in handy:
+        </p>
         <Code>{`<p class="h1">Heading 1</p>
 <p class="h2">Heading 2</p>
 <p class="h3">Heading 3</p>
 <p class="h4">Heading 4</p>
 <p class="h5">Heading 5</p>
 <p class="h6">Heading 6</p>`}</Code>
-        <p>In the above example, there are 6 paragraph elements styled to look like <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code>. Heading classes folow the <code>.h*</code> class structure, where <code>*</code> can be a number between 1 and 6.</p>
+        <p>
+            In the above example, there are 6 paragraph elements styled to look
+            like <code>&lt;h1&gt;</code> through <code>&lt;h6&gt;</code>.
+            Heading classes folow the <code>.h*</code> class structure, where{' '}
+            <code>*</code> can be a number between 1 and 6.
+        </p>
         <Alert>
-            <p>While both headings and heading classes change the font size and and margins, headings do not have a font weight applied to them (using the browser default) while heading classes have <code>font-weight: bold</code> applied to them.</p>
+            <p>
+                While both headings and heading classes change the font size and
+                and margins, headings do not have a font weight applied to them
+                (using the browser default) while heading classes have{' '}
+                <code>font-weight: bold</code> applied to them.
+            </p>
         </Alert>
         <h2>Paragraphs &amp; lists</h2>
         <p>Paragraphs and lists have pretty simple styling applied to them:</p>
@@ -71,19 +116,44 @@ const IndexPage = () => (
     <li>Ordered list item 1</li>
     <li>Ordered list item 1</li>
 </ol>`}</Code>
-        <p>In the above example, there's a paragraph, an unordered list, and an ordered list. All of these elements have a bottom margin of <code>1rem</code>.</p>
+        <p>
+            In the above example, there's a paragraph, an unordered list, and an
+            ordered list. All of these elements have a bottom margin of{' '}
+            <code>1rem</code>.
+        </p>
         <Alert>
-            <p>While unordered and ordered lists have a bottom margin applied to them, this bottom margin will be removed when nested inside another unordered or ordered list; This is to retain proper line height.</p>
+            <p>
+                While unordered and ordered lists have a bottom margin applied
+                to them, this bottom margin will be removed when nested inside
+                another unordered or ordered list; This is to retain proper line
+                height.
+            </p>
         </Alert>
         <h2>Other elements</h2>
         <p>More style resets have been applied to the following elements:</p>
         <ul>
-            <li><code>&lt;small&gt;</code> has a font size of <code>.5em</code>.</li>
-            <li><code>&lt;strong&gt;</code> and <code>&lt;dt&gt;</code> have a font weight of <code>bold</code>.</li>
-            <li><code>&lt;em&gt;</code> has a font style of <code>italic</code>.</li>
-            <li><code>&lt;dd&gt;</code> has a bottom margin of <code>.5rem</code>.</li>
-            <li><code>&lt;blockquote&gt;</code> has a margin of <code>0 0 1rem</code> and a font size of <code>1.25rem</code>.</li>
-            <li><code>&lt;fieldset&gt;</code> has a minimum width, margin, padding, and border of <code>0</code>.</li>
+            <li>
+                <code>&lt;small&gt;</code> has a font size of <code>.5em</code>.
+            </li>
+            <li>
+                <code>&lt;strong&gt;</code> and <code>&lt;dt&gt;</code> have a
+                font weight of <code>bold</code>.
+            </li>
+            <li>
+                <code>&lt;em&gt;</code> has a font style of <code>italic</code>.
+            </li>
+            <li>
+                <code>&lt;dd&gt;</code> has a bottom margin of{' '}
+                <code>.5rem</code>.
+            </li>
+            <li>
+                <code>&lt;blockquote&gt;</code> has a margin of{' '}
+                <code>0 0 1rem</code> and a font size of <code>1.25rem</code>.
+            </li>
+            <li>
+                <code>&lt;fieldset&gt;</code> has a minimum width, margin,
+                padding, and border of <code>0</code>.
+            </li>
         </ul>
     </Layout>
 );

--- a/src/pages/utilities.js
+++ b/src/pages/utilities.js
@@ -6,7 +6,7 @@ import Layout from '../components/layout';
 import SEO    from '../components/seo';
 
 const title     = 'Utility classes',
-    description = 'In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there\'s something you need to adjust, there\'s probably a utility class for it!';
+    description = 'In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there\'s something you need to adjust, there\'s probably a utility class for it.';
 
 const Summary = () => (
     <>

--- a/src/pages/utilities.js
+++ b/src/pages/utilities.js
@@ -1,37 +1,49 @@
 import React from 'react';
 
-import Alert  from '../components/alert';
-import Code   from '../components/code';
+import Alert from '../components/alert';
+import Code from '../components/code';
 import Layout from '../components/layout';
-import SEO    from '../components/seo';
+import SEO from '../components/seo';
 
-const title     = 'Utility classes',
-    description = 'In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there\'s something you need to adjust, there\'s probably a utility class for it.';
+const title = 'Utility classes',
+    description =
+        "In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there's something you need to adjust, there's probably a utility class for it.";
 
 const Summary = () => (
     <>
-        <h1>{ title }</h1>
-        <p>{ description }</p>
+        <h1>{title}</h1>
+        <p>{description}</p>
     </>
 );
 
 const IndexPage = () => (
-    <Layout summary={ Summary }>
-        <SEO
-            title={ title }
-            description={ description } />
+    <Layout summary={Summary}>
+        <SEO title={title} description={description} />
         <h2>Text alignment</h2>
         <p>Chassis.css provides 4 basic text alignment classes:</p>
         <Code>{`<p class="t-l">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent lacus mi, malesuada nec elit dignissim, tristique suscipit massa. Pellentesque in consequat tellus. Nullam tincidunt magna non accumsan elementum. Vivamus euismod, justo a aliquam aliquam, sapien turpis iaculis ipsum, ac vulputate metus lorem eget orci.</p>
 <p class="t-c">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent lacus mi, malesuada nec elit dignissim, tristique suscipit massa. Pellentesque in consequat tellus. Nullam tincidunt magna non accumsan elementum. Vivamus euismod, justo a aliquam aliquam, sapien turpis iaculis ipsum, ac vulputate metus lorem eget orci.</p>
 <p class="t-r">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent lacus mi, malesuada nec elit dignissim, tristique suscipit massa. Pellentesque in consequat tellus. Nullam tincidunt magna non accumsan elementum. Vivamus euismod, justo a aliquam aliquam, sapien turpis iaculis ipsum, ac vulputate metus lorem eget orci.</p>
 <p class="t-j">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent lacus mi, malesuada nec elit dignissim, tristique suscipit massa. Pellentesque in consequat tellus. Nullam tincidunt magna non accumsan elementum. Vivamus euismod, justo a aliquam aliquam, sapien turpis iaculis ipsum, ac vulputate metus lorem eget orci.</p>`}</Code>
-        <p>In the above example, there are 4 paragraphs using the 4 text alignment classes. Text alignment classes folow the <code>.t-*</code> class structure, where <code>*</code> can be one of the following letters:</p>
+        <p>
+            In the above example, there are 4 paragraphs using the 4 text
+            alignment classes. Text alignment classes folow the{' '}
+            <code>.t-*</code> class structure, where <code>*</code> can be one
+            of the following letters:
+        </p>
         <ul>
-            <li><code>l</code> means "left" and aligns text to the left.</li>
-            <li><code>c</code> means "center" and aligns text in the center.</li>
-            <li><code>r</code> means "right" and aligns text to the right.</li>
-            <li><code>j</code> means "justified" and justifies the text.</li>
+            <li>
+                <code>l</code> means "left" and aligns text to the left.
+            </li>
+            <li>
+                <code>c</code> means "center" and aligns text in the center.
+            </li>
+            <li>
+                <code>r</code> means "right" and aligns text to the right.
+            </li>
+            <li>
+                <code>j</code> means "justified" and justifies the text.
+            </li>
         </ul>
         <h2>List styles</h2>
         <p>You can change the style of a list with 2 list style classes:</p>
@@ -45,65 +57,178 @@ const IndexPage = () => (
     <li>Inline list item 2</li>
     <li>Inline list item 3</li>
 </ul>`}</Code>
-        <p>In the above example, there are two unordered lists, the first unstyled and the second inline. List style classes follow the <code>.l-</code> class structure, where <code>*</code> can be one of the following letters:</p>
+        <p>
+            In the above example, there are two unordered lists, the first
+            unstyled and the second inline. List style classes follow the{' '}
+            <code>.l-</code> class structure, where <code>*</code> can be one of
+            the following letters:
+        </p>
         <ul>
-            <li><code>u</code> means "unstyled" and unstyles the list.</li>
-            <li><code>i</code> means "inline" and makes each list item <code>display: inline-block</code>.</li>
+            <li>
+                <code>u</code> means "unstyled" and unstyles the list.
+            </li>
+            <li>
+                <code>i</code> means "inline" and makes each list item{' '}
+                <code>display: inline-block</code>.
+            </li>
         </ul>
         <h2>Screen readers</h2>
-        <p>Sometimes while not wanting to display text it is important to allow folks using screen readers to contextually understand what's going on; This is where screen reader classes come in handy! The following are the screen reader classes available:</p>
+        <p>
+            Sometimes while not wanting to display text it is important to allow
+            folks using screen readers to contextually understand what's going
+            on; This is where screen reader classes come in handy! The following
+            are the screen reader classes available:
+        </p>
         <ul>
-            <li><code>.sr</code> means "screen reader" and will hide the element while still being readable to screen readers.</li>
-            <li><code>.sr-f</code> means "screen reader focusable" and will hide the element until focused.</li>
+            <li>
+                <code>.sr</code> means "screen reader" and will hide the element
+                while still being readable to screen readers.
+            </li>
+            <li>
+                <code>.sr-f</code> means "screen reader focusable" and will hide
+                the element until focused.
+            </li>
         </ul>
         <h2>Margins &amp; padding adjustments</h2>
-        <p>Some of the most extensive utility classes available are the margin and padding adjustment classes, allowing you to manipulate the margins and padding of an element in any way you see fit.</p>
+        <p>
+            Some of the most extensive utility classes available are the margin
+            and padding adjustment classes, allowing you to manipulate the
+            margins and padding of an element in any way you see fit.
+        </p>
         <h3>Margin adjustments</h3>
-        <p>Margin adjustment classes follow the <code>.m$-*</code> class structure, where <code>$</code> signifies the side of adjustment and <code>*</code> signifies the amount of adjustment.</p>
-        <p><code>$</code> can be one of the following letters:</p>
+        <p>
+            Margin adjustment classes follow the <code>.m$-*</code> class
+            structure, where <code>$</code> signifies the side of adjustment and{' '}
+            <code>*</code> signifies the amount of adjustment.
+        </p>
+        <p>
+            <code>$</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>t</code> means "top" and adjusts the top margin of the element.</li>
-            <li><code>r</code> means "right" and adjusts the right margin of the element.</li>
-            <li><code>b</code> means "bottom" and adjusts the bottom margin of the element.</li>
-            <li><code>l</code> means "left" and adjusts the left margin of the element.</li>
+            <li>
+                <code>t</code> means "top" and adjusts the top margin of the
+                element.
+            </li>
+            <li>
+                <code>r</code> means "right" and adjusts the right margin of the
+                element.
+            </li>
+            <li>
+                <code>b</code> means "bottom" and adjusts the bottom margin of
+                the element.
+            </li>
+            <li>
+                <code>l</code> means "left" and adjusts the left margin of the
+                element.
+            </li>
         </ul>
         <Alert>
-            <p>If <code>$</code> is omitted, the margins of all sides of an element will be adjusted, e.g. <code>.m-*</code></p>
+            <p>
+                If <code>$</code> is omitted, the margins of all sides of an
+                element will be adjusted, e.g. <code>.m-*</code>
+            </p>
         </Alert>
-        <p><code>*</code> can be one of the following letters:</p>
+        <p>
+            <code>*</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>a</code> means "auto" and applies a margin value of <code>auto</code>.</li>
-            <li><code>z</code> means "zero" and applies a margin value of <code>0</code>.</li>
-            <li><code>t</code> means "third" and applies a margin value of <code>5px</code>, or a third of <code>15px</code>.</li>
-            <li><code>h</code> means "half" and applies a margin value of <code>7.5px</code>, or a half of <code>15px</code>.</li>
-            <li><code>f</code> means "full" and applies a margin value of <code>15px</code>.</li>
-            <li><code>d</code> means "double" and applies a margin value of <code>30px</code>, or <code>15px</code> doubled.</li>
+            <li>
+                <code>a</code> means "auto" and applies a margin value of{' '}
+                <code>auto</code>.
+            </li>
+            <li>
+                <code>z</code> means "zero" and applies a margin value of{' '}
+                <code>0</code>.
+            </li>
+            <li>
+                <code>t</code> means "third" and applies a margin value of{' '}
+                <code>5px</code>, or a third of <code>15px</code>.
+            </li>
+            <li>
+                <code>h</code> means "half" and applies a margin value of{' '}
+                <code>7.5px</code>, or a half of <code>15px</code>.
+            </li>
+            <li>
+                <code>f</code> means "full" and applies a margin value of{' '}
+                <code>15px</code>.
+            </li>
+            <li>
+                <code>d</code> means "double" and applies a margin value of{' '}
+                <code>30px</code>, or <code>15px</code> doubled.
+            </li>
         </ul>
         <Alert>
-            <p>If <code>*</code> is prefixed with <code>n</code>, the amount of adjusment will be negative. This does not apply to the "auto" <code>a</code> or "zero" <code>z</code> adjustment amounts.</p>
+            <p>
+                If <code>*</code> is prefixed with <code>n</code>, the amount of
+                adjusment will be negative. This does not apply to the "auto"{' '}
+                <code>a</code> or "zero" <code>z</code> adjustment amounts.
+            </p>
         </Alert>
         <h3>Padding adjustments</h3>
-        <p>Padding adjustment classes follow the <code>.p$-*</code> class structure, where <code>$</code> signifies the side of adjustment and <code>*</code> signifies the amount of adjustment.</p>
-        <p><code>$</code> can be one of the following letters:</p>
+        <p>
+            Padding adjustment classes follow the <code>.p$-*</code> class
+            structure, where <code>$</code> signifies the side of adjustment and{' '}
+            <code>*</code> signifies the amount of adjustment.
+        </p>
+        <p>
+            <code>$</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>t</code> means "top" and adjusts the top padding of the element.</li>
-            <li><code>r</code> means "right" and adjusts the right padding of the element.</li>
-            <li><code>b</code> means "bottom" and adjusts the bottom padding of the element.</li>
-            <li><code>l</code> means "left" and adjusts the left padding of the element.</li>
+            <li>
+                <code>t</code> means "top" and adjusts the top padding of the
+                element.
+            </li>
+            <li>
+                <code>r</code> means "right" and adjusts the right padding of
+                the element.
+            </li>
+            <li>
+                <code>b</code> means "bottom" and adjusts the bottom padding of
+                the element.
+            </li>
+            <li>
+                <code>l</code> means "left" and adjusts the left padding of the
+                element.
+            </li>
         </ul>
         <Alert>
-            <p>If <code>$</code> is omitted, the padding of all sides of an element will be adjusted, e.g. <code>.p-*</code></p>
+            <p>
+                If <code>$</code> is omitted, the padding of all sides of an
+                element will be adjusted, e.g. <code>.p-*</code>
+            </p>
         </Alert>
-        <p><code>*</code> can be one of the following letters:</p>
+        <p>
+            <code>*</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>z</code> means "zero" and applies a padding value of <code>0</code>.</li>
-            <li><code>t</code> means "third" and applies a padding value of <code>5px</code>, or a third of <code>15px</code>.</li>
-            <li><code>h</code> means "half" and applies a padding value of <code>7.5px</code>, or a half of <code>15px</code>.</li>
-            <li><code>f</code> means "full" and applies a padding value of <code>15px</code>.</li>
-            <li><code>d</code> means "double" and applies a padding value of <code>30px</code>, or <code>15px</code> doubled.</li>
+            <li>
+                <code>z</code> means "zero" and applies a padding value of{' '}
+                <code>0</code>.
+            </li>
+            <li>
+                <code>t</code> means "third" and applies a padding value of{' '}
+                <code>5px</code>, or a third of <code>15px</code>.
+            </li>
+            <li>
+                <code>h</code> means "half" and applies a padding value of{' '}
+                <code>7.5px</code>, or a half of <code>15px</code>.
+            </li>
+            <li>
+                <code>f</code> means "full" and applies a padding value of{' '}
+                <code>15px</code>.
+            </li>
+            <li>
+                <code>d</code> means "double" and applies a padding value of{' '}
+                <code>30px</code>, or <code>15px</code> doubled.
+            </li>
         </ul>
         <h2>Visibility</h2>
-        <p>Sometimes you want to show an element only at a certain viewport size, or sometimes you want hide an element at a certain viewport size; In both cases, that's where visibility classes come to the rescue!</p>
+        <p>
+            Sometimes you want to show an element only at a certain viewport
+            size, or sometimes you want hide an element at a certain viewport
+            size; In both cases, that's where visibility classes come to the
+            rescue!
+        </p>
         <Code>{`<div class="container">
     <div class="row">
         <div class="col xs-s">This is only visible on extra small viewports.</div>
@@ -118,22 +243,65 @@ const IndexPage = () => (
         <div class="col lg-h">This is hidden on large viewports.</div>
     </div>
 </div>`}</Code>
-        <p>In the above example, there are 2 rows with 4 auto width columns, each with a visibility class. In the first row, each column is set to only show at a certain viewport size, hence why only 1 of the 4 columns is visible. In the second row, each column is set to hide at a certain viewport size, hence why only 3 of the 4 columns are visible. To get a better visualization of how this works, adjust the width of your browser window!</p>
-        <p>Visibility classes follow the <code>.$-*</code> class structure, where <code>$</code> signifies the viewport width and <code>*</code> signifies the visibility state.</p>
-        <p><code>$</code> can be one of the following:</p>
+        <p>
+            In the above example, there are 2 rows with 4 auto width columns,
+            each with a visibility class. In the first row, each column is set
+            to only show at a certain viewport size, hence why only 1 of the 4
+            columns is visible. In the second row, each column is set to hide at
+            a certain viewport size, hence why only 3 of the 4 columns are
+            visible. To get a better visualization of how this works, adjust the
+            width of your browser window!
+        </p>
+        <p>
+            Visibility classes follow the <code>.$-*</code> class structure,
+            where <code>$</code> signifies the viewport width and <code>*</code>{' '}
+            signifies the visibility state.
+        </p>
+        <p>
+            <code>$</code> can be one of the following:
+        </p>
         <ul>
-            <li><code>xs</code> means "extra small" and targets viewports less than 768px wide.</li>
-            <li><code>sm</code> means "small" and targets viewports greater than or equal to 768px wide but less than 992px wide.</li>
-            <li><code>md</code> means "medium" and targets viewports greater than or equal to 992px wide but less than 1200px wide.</li>
-            <li><code>lg</code> means "large" and targets viewports greater than or equal to 1200px wide.</li>
+            <li>
+                <code>xs</code> means "extra small" and targets viewports less
+                than 768px wide.
+            </li>
+            <li>
+                <code>sm</code> means "small" and targets viewports greater than
+                or equal to 768px wide but less than 992px wide.
+            </li>
+            <li>
+                <code>md</code> means "medium" and targets viewports greater
+                than or equal to 992px wide but less than 1200px wide.
+            </li>
+            <li>
+                <code>lg</code> means "large" and targets viewports greater than
+                or equal to 1200px wide.
+            </li>
         </ul>
-        <p><code>*</code> can be one of the following letters:</p>
+        <p>
+            <code>*</code> can be one of the following letters:
+        </p>
         <ul>
-            <li><code>s</code> means "show" and applies <code>display: block</code> to the element at the targeted viewport width and applies <code>display: none</code> to the element at all other viewport widths.</li>
-            <li><code>h</code> means "hide" and applies applies <code>display: none</code> to the element at the targeted viewport width and applies <code>display: hide</code> to the element at all other viewport widths.</li>
+            <li>
+                <code>s</code> means "show" and applies{' '}
+                <code>display: block</code> to the element at the targeted
+                viewport width and applies <code>display: none</code> to the
+                element at all other viewport widths.
+            </li>
+            <li>
+                <code>h</code> means "hide" and applies applies{' '}
+                <code>display: none</code> to the element at the targeted
+                viewport width and applies <code>display: hide</code> to the
+                element at all other viewport widths.
+            </li>
         </ul>
         <Alert type="warning">
-            <p>Visibility classes should not be applied to <code>display: flex</code> elements, such as rows, as they are intended for <code>display: block</code> elements and will break flexbox functionality.</p>
+            <p>
+                Visibility classes should not be applied to{' '}
+                <code>display: flex</code> elements, such as rows, as they are
+                intended for <code>display: block</code> elements and will break
+                flexbox functionality.
+            </p>
         </Alert>
     </Layout>
 );

--- a/src/pages/utilities.js
+++ b/src/pages/utilities.js
@@ -6,8 +6,7 @@ import Layout from '../components/layout';
 import SEO from '../components/seo';
 
 const title = 'Utility classes',
-    description =
-        "In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there's something you need to adjust, there's probably a utility class for it.";
+    description = 'In addition to its grid system and style resets, chassis.css provides verbose and easy-to-use utility classes to manipulate just about everything. If there\'s something you need to adjust, there\'s probably a utility class for it.';
 
 const Summary = () => (
     <>

--- a/src/sass/components/footer.sass
+++ b/src/sass/components/footer.sass
@@ -30,8 +30,6 @@
     color: $slate
     &:hover, &:focus
         color: $black
-    &:visited
-        color: $slate
 
 .footer__links
     display: flex

--- a/src/sass/components/header.sass
+++ b/src/sass/components/header.sass
@@ -53,6 +53,7 @@
         color: $white
         transition: opacity $transition-timing
         &:hover, &:focus
+            color: $white
             opacity: .8
 
     p

--- a/src/sass/components/header.sass
+++ b/src/sass/components/header.sass
@@ -54,8 +54,6 @@
         transition: opacity $transition-timing
         &:hover, &:focus
             opacity: .8
-        &:visited
-            color: $white
 
     p
         margin-bottom: 0
@@ -93,8 +91,6 @@
         background-color: rgba($black, .2)
         text-decoration: none
         color: $white
-    &:visited
-        color: $white
 
 .header__nav-link--active
     background-color: $white
@@ -104,8 +100,6 @@
         background-color: $light-gray
         text-decoration: none
         color: $black
-    &:visited
-        color: $slate
 
 .header__summary p
     line-height: 1.5

--- a/src/sass/components/layout.sass
+++ b/src/sass/components/layout.sass
@@ -17,8 +17,6 @@ a
         color: darken($blue, 10%)
     &:focus
         color: $red
-    &:visited
-        color: $purple
 
 *:not(pre) > code
     padding: .025rem .25rem

--- a/src/sass/pages/index.sass
+++ b/src/sass/pages/index.sass
@@ -45,6 +45,7 @@
     padding: 1rem
     border: 1px solid darken($light-gray, 5%)
     border-radius: $border-radius
+    text-align: center
     box-shadow: $drop-shadow
 
 .index__perk-title


### PR DESCRIPTION
- Updated chassis.css to 4.0.1
- Updated the version in the Gatsby config file to 4.0.1
- Updated the index page SASS to center align the text within the perks
- Updated the layout component SASS, as well as the footer and header component SASS, to remove link visited styling (was causing color flickering on hover)
- Updated the descriptions of the reset and utilities pages to remove the ending exclamation point
- Updated the homepage to include the changelog for the 4.0.1 release, as well as move the installation code box above the changelog
- Updated the grid page to include documentation for the new "align content" modifier classes, and removed the warnings on vertical and horizontal alignment modifier classes (as it is no longer an issue with the 4.0.1 release)
- Reformatted all source files
- Spell-checked all pages and made corrections
- Updated the header component SASS to fix a hover/focus issue with the title/version link
- 4.0.1